### PR TITLE
Update e2e test for pin endpoint

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -7,18 +7,20 @@ describe('AppController (e2e)', () => {
   let app: INestApplication;
 
   beforeEach(async () => {
+    const pin = process.env.PIN || '0000';
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [AppModule.forRoot(pin)],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it('/pin (GET)', () => {
+    const pin = process.env.PIN || '0000';
     return request(app.getHttpServer())
-      .get('/')
+      .get(`/pin?q=${pin}`)
       .expect(200)
-      .expect('Hello World!');
+      .expect('success');
   });
 });


### PR DESCRIPTION
## Summary
- test `/pin` endpoint instead of `/`
- configure e2e module with `AppModule.forRoot`

## Testing
- `npm test --silent` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_684006f12938832abc6e5e5403ff5dc1