### PR TITLE
Refactor: Adjust UI spacing for modern look and feel

### DIFF
--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -28,11 +28,11 @@ html, body{
     --start: flex-start;
     --end: flex-end;
     /* gap size vars */
-    --xl: 40px;
-    --lg: 28px;
-    --md: 20px;
-    --sm: 16px;
-    --xs: 12px;
+    --xl: 48px;
+    --lg: 32px;
+    --md: 24px;
+    --sm: 18px;
+    --xs: 14px;
     /* font weight vars */
     --strong: 600;
     --regular: 400;
@@ -91,11 +91,11 @@ html, body{
 
 @media screen and (max-width: 768px){
     :root{
-        --xl: 32px;
-        --lg: 20px;
-        --md: 16px;
-        --sm: 12px;
-        --xs: 8px;
+        --xl: 40px;
+        --lg: 28px;
+        --md: 20px;
+        --sm: 16px;
+        --xs: 12px;
 
         --display: 3.5rem;
         --headline: 2rem;
@@ -107,11 +107,11 @@ html, body{
 
 @media screen and (max-width: 480px){ /* mobile */
     :root{
-        --xl: 24px;
-        --lg: 16px;
-        --md: 12px;
-        --sm: 8px;
-        --xs: 6px;
+        --xl: 32px;
+        --lg: 24px;
+        --md: 18px;
+        --sm: 14px;
+        --xs: 10px;
 
         --display: 3rem;
         --headline: 1.75rem;


### PR DESCRIPTION
I've updated CSS variables in global.css to increase spacing for a more modern and visually balanced UI across mobile, tablet, and desktop screen sizes.

- I increased default (desktop) spacing variables (--xl, --lg, --md, --sm, --xs).
- I adjusted spacing variables for tablet (max-width: 768px) media query.
- I adjusted spacing variables for mobile (max-width: 480px) media query.

These changes aim to improve readability and overall user experience by providing more generous spacing between UI elements.